### PR TITLE
Limit the circumstances in which CI is kicked off

### DIFF
--- a/.github/workflows/all_ci.yml
+++ b/.github/workflows/all_ci.yml
@@ -9,7 +9,13 @@ run-name: Mac and Linux CI
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths
 # There is a solution if this type of optimization is preferred. See:
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 # This allows a subsequently queued workflow run to interrupt previous runs.
 concurrency:

--- a/.github/workflows/generic_ci.yml
+++ b/.github/workflows/generic_ci.yml
@@ -20,6 +20,8 @@ jobs:
   common-build-and-test:
     name: ci
     runs-on: ${{ inputs.os }}
+    # Don't inflict actual CI work on forks that happen to have actions enabled.
+    if: github.repository_owner == 'flexible-collision-library'
     env:
       CC: ${{ inputs.compiler == 'gcc' && 'gcc' || 'clang' }}
       CXX: ${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}


### PR DESCRIPTION
With the previous spelling, if a forked version of FCL had actions enabled, then every push to every branch would kick off a mac/ubuntu CI event. This is ridiculous and telling forkers to not allow github actions is not the solution.

So, we take two strategies to spare the FCL contributors:

 1. We limit the CI to operate only on the master branch.
 2. The CI tasks become no-ops unless it is run on the FCL repo. This will still cause actions to be triggered, but they will silently do nothing in zero time.